### PR TITLE
Fix octet string decoding in Stubs.py

### DIFF
--- a/dmt/A_mappers/Stubs.py
+++ b/dmt/A_mappers/Stubs.py
@@ -398,7 +398,7 @@ grep for the errorcode value inside ASN1SCC generated headers."""
                 retval += bytes([self.Get(reset=False)])
                 self._params.pop()
             self.Reset()
-            return retval.decode("utf-8")
+            return retval
         else:
             retval = ""
             strLength = self.GetLength(False)


### PR DESCRIPTION
Hello,

The OCTET STRING ASN.1 data type is designated for arbitrary binary data. At the moment, when Python 3 code is generated from ASN, and octet strings' contents are accessed, these contents are assumed to be valid UTF-8 strings. This doesn't hold for our usecase. We patched the GetPyString model to simply return the bytestring representation which makes no assumptions on the values of the bytes. It is likely that this will break tests, so if this is merged, adjust them accordingly.